### PR TITLE
Fixes utf8 Umlaute

### DIFF
--- a/__tests__/serialize.test.js
+++ b/__tests__/serialize.test.js
@@ -9,6 +9,7 @@ it ('serializes primitives', () => {
     expect(php.serialize(-2)).toEqual('i:-2;');
     expect(php.serialize(3.14)).toEqual('d:3.1400000000000001;');
     expect(php.serialize("hello")).toEqual('s:5:"hello";');
+    expect(php.serialize("Köln")).toEqual('s:5:"Köln";');
     expect(php.serialize("0")).toEqual('i:0;');
     expect(php.serialize("")).toEqual('s:0:"";');
 });

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var serialize = (v, options) => {
             ret = 'd:' + v.toFixed(16) + ';';
         }
     } else if (typeof v === "string") {
-        ret = "s:" + v.length + ':"' + v + '";';
+        ret = "s:" + Buffer.byteLength(v, 'utf8') + ':"' + v + '";';
     } else if (v[options.metakey]) {
         var meta = v[options.metakey];
         var properties = Object.keys(v).filter(k => { return k !== options.metakey; }).map(k => {


### PR DESCRIPTION
When trying to serialize strings with umlaute (ö, ä, ...), that umlaut will be counted as 1 byte instead of 2 bytes.

This pull requests uses Buffer.byteLength with uf8 to count the length for strings and therefore will use the correct byte count.