### PR TITLE
Fixes NaN serialization

### DIFF
--- a/__tests__/serialize.test.js
+++ b/__tests__/serialize.test.js
@@ -11,6 +11,7 @@ it ('serializes primitives', () => {
     expect(php.serialize("hello")).toEqual('s:5:"hello";');
     expect(php.serialize("Köln")).toEqual('s:5:"Köln";');
     expect(php.serialize("0")).toEqual('i:0;');
+    expect(php.serialize(NaN)).toEqual('d:NAN;');
     expect(php.serialize("")).toEqual('s:0:"";');
 });
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ var serialize = (v, options) => {
     } else if (typeof v === 'number' || (typeof v === 'string' && "" + (+v) === v)) {
         if (v % 1 === 0) {
             ret = 'i:' + v + ';';
-        } else {
+        } else if (isNaN(v)) {
+            ret = 'd:NAN;';
+        }
+        else {
             ret = 'd:' + v.toFixed(16) + ';';
         }
     } else if (typeof v === "string") {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ var serialize = (v, options) => {
             ret = 'i:' + v + ';';
         } else if (isNaN(v)) {
             ret = 'd:NAN;';
-        }
-        else {
+        } else {
             ret = 'd:' + v.toFixed(16) + ';';
         }
     } else if (typeof v === "string") {


### PR DESCRIPTION
If we encounter a NaN value, the serialization should output 'd:NAN;' for php compatibility. In JS the default output is 'd:NaN;' which results in errors in php unserialize.